### PR TITLE
Exclude Pentaho dependency from Hive and SQL to avoid build problems

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -522,6 +522,10 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
+                                <exclusion>
+                                        <groupId>org.pentaho</groupId>
+                                        <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                                </exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -431,6 +431,10 @@ under the License.
 					<groupId>commons-lang</groupId>
 					<artifactId>commons-lang</artifactId>
 				</exclusion>
+                                <exclusion>
+					<groupId>org.pentaho</groupId>
+					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
- Add <exclusion> block to the pom.xml file of flink-connector-hive and flink-sql-client
  - these have dependency org.pentaho and thus try to download from conjars.org repository but this repository is dead and the build fails
  - this dependency is also excluded in the original flink 1.16 (https://github.com/apache/flink/pull/22299)